### PR TITLE
base path for testing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "https://blogs.nopcode.org/brainstorm"
+baseurl = "/brainstorm"
 languageCode = "en-us"
 title = "BrainBlog"
 theme = "hugo-lithium"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
 	command = "hugo -d public/brainstorm"
+	publish = "public"
 [build.environment]
 	HUGO_VERSION = "0.55.6"


### PR DESCRIPTION
When I made these simple changes the site deployed to the `/brainstorm` path:

https://deploy-preview-1--brainblog.netlify.com/brainstorm/